### PR TITLE
SEIN-74:Fix PDF generation for nfe throwing a error

### DIFF
--- a/libs/CommonNFePHP.class.php
+++ b/libs/CommonNFePHP.class.php
@@ -166,6 +166,7 @@ class CommonNFePHP
     protected function __ymd2dmy($data = '')
     {
         if (!empty($data)) {
+            $data = substr($data,0,10);
             $needle = "/";
             if (strstr($data, "-")) {
                 $needle = "-";

--- a/libs/DanfeNFePHP.class.php
+++ b/libs/DanfeNFePHP.class.php
@@ -1232,7 +1232,15 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         $texto = 'DATA DA EMISSÃO';
         $aFont = array('font'=>$this->fontePadrao,'size'=>6,'style'=>'');
         $this->__textBox($x,$y,$w,$h,$texto,$aFont,'T','L',1,'');
-        $texto = $this->__ymd2dmy($this->ide->getElementsByTagName("dEmi")->item(0)->nodeValue);
+
+        $dEmi = $this->ide->getElementsByTagName("dEmi")->item(0);
+        if (!$dEmi) {
+            $dEmi = $this->ide->getElementsByTagName("dhEmi")->item(0);
+        }
+        if($dEmi) {
+            $texto = $this->__ymd2dmy($dEmi->nodeValue);
+        }
+
         $aFont = array('font'=>$this->fontePadrao,'size'=>10,'style'=>'B');
         if( $this->orientacao == 'P' ){
             $this->__textBox($x,$y,$w,$h,$texto,$aFont,'B','C',0,'');
@@ -1322,9 +1330,14 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         $texto = 'INSCRIÇÃO ESTADUAL';
         $aFont = array('font'=>$this->fontePadrao,'size'=>6,'style'=>'');
         $this->__textBox($x,$y,$w,$h,$texto,$aFont,'T','L',1,'');
-        $texto = $this->dest->getElementsByTagName("IE")->item(0)->nodeValue;
-        $aFont = array('font'=>$this->fontePadrao,'size'=>10,'style'=>'B');
-        $this->__textBox($x,$y,$w,$h,$texto,$aFont,'B','C',0,'');
+
+        $IE = $this->dest->getElementsByTagName("IE")->item(0);
+        if($IE) {
+            $texto = $IE->nodeValue;
+            $aFont = array('font' => $this->fontePadrao, 'size' => 10, 'style' => 'B');
+            $this->__textBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
+        }
+
         //HORA DA SAÍDA
         $x += $w;
         $w = $wx;
@@ -2481,7 +2494,15 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
             $texto .= "AO LADO";
         }
         $texto .= ". EMISSÃO: ";
-        $texto .= $this->__ymd2dmy($this->ide->getElementsByTagName("dEmi")->item(0)->nodeValue) ." ";
+
+        $dEmi = $this->ide->getElementsByTagName("dEmi")->item(0);
+        if (!$dEmi) {
+            $dEmi = $this->ide->getElementsByTagName("dhEmi")->item(0);
+        }
+        if($dEmi) {
+            $texto = $this->__ymd2dmy($dEmi->nodeValue);
+        }
+
         $texto .= "VALOR TOTAL: R$ ";
         $texto .= number_format($this->ICMSTot->getElementsByTagName("vNF")->item(0)->nodeValue, 2, ",", ".") . " ";
         $texto .= "DESTINATÁRIO: ";
@@ -2597,7 +2618,14 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         if( $icmss > 0 ){
             $icmss = 1;
         }
-        $dd  = $this->ide->getElementsByTagName('dEmi')->item(0)->nodeValue;
+
+        $dd = $this->ide->getElementsByTagName("dEmi")->item(0);
+        if (!$dd) {
+            $dd = $this->ide->getElementsByTagName("dhEmi")->item(0);
+        }
+
+        $dd = substr($dd,0,10);
+
         $rpos = strrpos( $dd , '-' );
         $dd  = substr( $dd , $rpos +1 );
         $chave = sprintf( $forma ,$cUF , $this->tpEmis , $CNPJ , $vNF , $vICMS , $icmss , $dd );


### PR DESCRIPTION
#### O que esse PR faz?

Corrige a parte que está dando erro na biblioteca nfephp sobre "não confie em arrays".

#### Algum contexto que deve ser apresentado?

A geração do PDF dá alguns warnings pois nem todo cliente tem inscrição estadual. O valor é gravado como "NULL". Não existe verificação para isso atualmente na biblioteca.

#### Por onde começar a revisão?

libs/DanfeNFePHP.class.php

#### Como testar manualmente?

No charmander para testes.

Gerar uma nfp em um pokémon que não seja o charmander e verificar os logs. Verificar se o erro ainda está acontecendo no charmander.

https://kanuibr.atlassian.net/browse/SEIN-74
https://rpm.newrelic.com/accounts/94397/applications/6027592/traced_errors/9b1190-a0293b27-4a88-11e5-9380-f8bc124250a8

| Pergunta | R |
| :------------- | :-------------: |
| Esse PR contém migrations?           | *Não*  |
| Alguma dependência nova no Composer? | *Não* |
| Alguma configuração nova no Puppet/Ansible?  | *Não*|